### PR TITLE
Remove leading white space from the item text

### DIFF
--- a/denops/@ddu-sources/qf.ts
+++ b/denops/@ddu-sources/qf.ts
@@ -163,7 +163,7 @@ export class Source extends BaseSource<Params> {
                   path,
                 ).replaceAll(
                   "%t",
-				  citem.text.replace(/^\s+/, ""),
+                  citem.text.replace(/^\s+/, ""),
                 );
 
               // set action data

--- a/denops/@ddu-sources/qf.ts
+++ b/denops/@ddu-sources/qf.ts
@@ -163,7 +163,7 @@ export class Source extends BaseSource<Params> {
                   path,
                 ).replaceAll(
                   "%t",
-                  citem.text,
+				  citem.text.replace(/^\s+/, ""),
                 );
 
               // set action data


### PR DESCRIPTION
I made a pull request to remove leading white spaces from text lines in qf-source to improve readability. 
Even if there were leading white spaces in the original text, they are now removed in the updated version.